### PR TITLE
Disable SELinux when using Planter

### DIFF
--- a/roles/install-planter/tasks/main.yml
+++ b/roles/install-planter/tasks/main.yml
@@ -4,3 +4,10 @@
     state: link
     src: "{{ ansible_env.HOME }}/{{ gopath }}/src/k8s.io/test-infra/planter"
     dest: "{{ ansible_env.HOME }}/{{ gopath }}/src/k8s.io/planter"
+
+- name: Set SELinux to permissive for build
+  become: true
+  become_user: root
+  selinux:
+    policy: targeted
+    state: permissive


### PR DESCRIPTION
When using Planter, SELinux can't be enabled, or your builds won't
start correctly.

Closes #11