### PR TITLE
Seperates role including from playbook

### DIFF
--- a/auto-kube-dev.yaml
+++ b/auto-kube-dev.yaml
@@ -1,11 +1,4 @@
 ---
 - hosts: all
-  tasks: []
-  roles:
-    - { role: verify-environment, when: "perform_hardware_checks" }
-    - { role: install-deps-utils, become: true, become_user: "root" }
-    - { role: install-go }
-    - { role: install-docker, become: true, become_user: "root" }
-    - { role: setup-repos }
-    - { role: install-bazel, when: "use_bazel_rpm" }
-    - { role: install-planter, when: "use_planter" }
+  tasks:
+    - include_tasks: builder.yml

--- a/builder.yml
+++ b/builder.yml
@@ -1,0 +1,9 @@
+---
+  roles:
+    - { role: verify-environment, when: "perform_hardware_checks" }
+    - { role: install-deps-utils, become: true, become_user: "root" }
+    - { role: install-go }
+    - { role: install-docker, become: true, become_user: "root" }
+    - { role: setup-repos }
+    - { role: install-bazel, when: "use_bazel_rpm" }
+    - { role: install-planter, when: "use_planter" }


### PR DESCRIPTION
In order to allow inclusion in kube-centos-ansible, break out the
role inclusion list from the main playbook run. Keeps this backwards
compatible with existing documentation.