### PR TITLE
[hotfix] Removes dependencies from internal roles

### DIFF
--- a/roles/install-planter/meta/main.yml
+++ b/roles/install-planter/meta/main.yml
@@ -1,4 +1,2 @@
 ---
-dependencies:
-  - { role: install-go }
-  - { role: install-docker }
+dependencies: []

--- a/roles/setup-repos/meta/main.yml
+++ b/roles/setup-repos/meta/main.yml
@@ -1,4 +1,2 @@
 ---
-dependencies:
-  - { role: install-deps-utils }
-  - { role: install-go }
+dependencies: []


### PR DESCRIPTION
When consuming auto-kube-dev externally, you cause issues with dependencies
in the metadata of the internal roles. This can cause roles to be run multiple
times, which is not desired.

For now, just drop the dependency management from the metadata in the internal
roles, because it's basically assumed you're going to manage the order of
internal role firing yourself.